### PR TITLE
Ignore Copado Package.xml

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ program
             if (fileName && fileName.substring(0,3) === 'src') {
 
                 //ignore changes to the package.xml file
-                if(fileName === 'src/package.xml') {
+                if(fileName.contains('package.xml')) {
                     return;
                 }
 


### PR DESCRIPTION
Copado package.xml is located in '/package.xml' and code is only looking for '/smp/package.xml' to ignore it. Check string for 'package.xml' in any part of the directory instead of just '/smp'